### PR TITLE
Override direction in Right to Left documents

### DIFF
--- a/src/less/stylesheet.less
+++ b/src/less/stylesheet.less
@@ -35,6 +35,9 @@ body {
 }
 
 .ngi-inspector {
+	/* Direction */
+	direction: ltr;
+	
 	/* Dimensions and Positioning */
 	position: fixed;
 	top: 0;


### PR DESCRIPTION
When the direction of root element becomes right to left the UI looks messy.